### PR TITLE
Add istanbul-ignore-fn fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+Add `istanbul-ignore-fn` fixture.
+
 ## 2.0.0
 
 Newer dependencies impacted the generated fixtures and source maps.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ If the exported `run(value)` is called with a value other than `42` the
 statement body won't execute, but this does not result in missing coverage. It
 would in the `branching` fixture.
 
+### `istanbul-ignore-fn`
+
+Like `istanbul-ignore`, but the if condition guards a function call. The
+function declaration is prefaced with `/* istanbul ignore next */`. The function
+won't execute unless the exported `run(value)` is called with `42`.
+
 ### `simple`
 
 See `src/simple.js`. Exports a `run()` function which returns `42`.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ See `src/branching.js`. Exports a `run(value)` function which returns `true` if
 
 ### `istanbul-ignore`
 
-Like `branching`, but the if condition is prefaced with a `/* istanbul ignore if */`
+Like `branching`, but the if condition is prefaced with a `/* istanbul ignore if
+ */`
 comment.
-
-When running `branching` with `value !== 42` the statement body won't execute.
-If you're using the fixture to test a code coverage tool that line will show up
-as missing coverage. If instead you use the `istanbul-ignore` fixture the
-coverage report will ignore the statement body.
 
 If the exported `run(value)` is called with a value other than `42` the
 statement body won't execute, but this does not result in missing coverage. It

--- a/fixtures/istanbul-ignore-fn-inline.js
+++ b/fixtures/istanbul-ignore-fn-inline.js
@@ -1,0 +1,16 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var q = function (a) {
+  if (a === 42) {
+    return bar();
+  }
+};
+exports.run = q;
+
+/* istanbul ignore next */
+
+var bar = function () {};
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlzdGFuYnVsLWlnbm9yZS1mbi5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7OztBQUFBLElBQU0sSUFBSSxhQUFLO0FBQ2IsTUFBSSxNQUFNLEVBQU4sRUFBVTtBQUNaLFdBQU8sS0FBUCxDQURZO0dBQWQ7Q0FEUTtRQUtJLE1BQUw7Ozs7QUFHVCxJQUFNLE1BQU0sWUFBTSxFQUFOIiwiZmlsZSI6ImlzdGFuYnVsLWlnbm9yZS1mbi5qcyIsInNvdXJjZVJvb3QiOiIuLi9zcmMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBxID0gYSA9PiB7XG4gIGlmIChhID09PSA0Mikge1xuICAgIHJldHVybiBiYXIoKVxuICB9XG59XG5leHBvcnQgeyBxIGFzIHJ1biB9XG5cbi8qIGlzdGFuYnVsIGlnbm9yZSBuZXh0ICovXG5jb25zdCBiYXIgPSAoKSA9PiB7fVxuIl19

--- a/fixtures/istanbul-ignore-fn-map-file.js
+++ b/fixtures/istanbul-ignore-fn-map-file.js
@@ -1,0 +1,16 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var q = function (a) {
+  if (a === 42) {
+    return bar();
+  }
+};
+exports.run = q;
+
+/* istanbul ignore next */
+
+var bar = function () {};
+//# sourceMappingURL=istanbul-ignore-fn-map-file.js.map

--- a/fixtures/istanbul-ignore-fn-map-file.js.map
+++ b/fixtures/istanbul-ignore-fn-map-file.js.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "sources": [
+    "istanbul-ignore-fn.js"
+  ],
+  "names": [],
+  "mappings": ";;;;;AAAA,IAAM,IAAI,aAAK;AACb,MAAI,MAAM,EAAN,EAAU;AACZ,WAAO,KAAP,CADY;GAAd;CADQ;QAKI,MAAL;;;;AAGT,IAAM,MAAM,YAAM,EAAN",
+  "file": "istanbul-ignore-fn.js",
+  "sourceRoot": "../src",
+  "sourcesContent": [
+    "const q = a => {\n  if (a === 42) {\n    return bar()\n  }\n}\nexport { q as run }\n\n/* istanbul ignore next */\nconst bar = () => {}\n"
+  ]
+}

--- a/fixtures/istanbul-ignore-fn-none.js
+++ b/fixtures/istanbul-ignore-fn-none.js
@@ -1,0 +1,15 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var q = function (a) {
+  if (a === 42) {
+    return bar();
+  }
+};
+exports.run = q;
+
+/* istanbul ignore next */
+
+var bar = function () {};

--- a/src/istanbul-ignore-fn.js
+++ b/src/istanbul-ignore-fn.js
@@ -1,0 +1,9 @@
+const q = a => {
+  if (a === 42) {
+    return bar()
+  }
+}
+export { q as run }
+
+/* istanbul ignore next */
+const bar = () => {}


### PR DESCRIPTION
Variant of the `istanbul-ignore` fixture, using a hint which ignores an entire function statement.